### PR TITLE
Update x64 library for tokens

### DIFF
--- a/auth.hpp
+++ b/auth.hpp
@@ -15,9 +15,9 @@ namespace KeyAuth {
 	class api {
 	public:
 
-		std::string name, ownerid, secret, version, url;
+		std::string name, ownerid, secret, version, url, path; 
 
-		api(std::string name, std::string ownerid, std::string secret, std::string version, std::string url) : name(name), ownerid(ownerid), secret(secret), version(version), url(url) {}
+		api(std::string name, std::string ownerid, std::string secret, std::string version, std::string url, std::string path) : name(name), ownerid(ownerid), secret(secret), version(version), url(url), path(path) {}
 
 		void ban(std::string reason = "");
 		void init();


### PR DESCRIPTION
This library had not been updated since tokens were added to the API. The issue that was occurring would be KeyAuth library would always believe it was successful, then would have an access violation eventually. 