### PR TITLE
Fix memory leaks and improve error handling in req() function

### DIFF
--- a/auth.hpp
+++ b/auth.hpp
@@ -105,12 +105,10 @@ namespace KeyAuth {
 		responsedata response;
 		Tfa tfa;
 	private:
+
 		std::string sessionid, enckey;
-
-		static std::string req(std::string data, std::string url);
-
+		static std::string req(const std::string& data, const std::string& url);
 		static void debugInfo(std::string data, std::string url, std::string response, std::string headers);
-
 		static void setDebug(bool value);
 		
 


### PR DESCRIPTION
1. Added curl_easy_cleanup(curl); to free resources after request
2. Changed to 2L (Enforces full hostname verification)
3. Added cleanup before calling error()
4. Properly convert to C-string XorStr("keyauth.win").c_str()
5. Proper Cleanup to Avoid Memory Leaks

Your original function doesn’t call curl_easy_cleanup(), which means CURL resources aren’t freed in case of errors.
this leads to memory leaks if the function is called multiple times (and its already called multiple times) almost every function 
in keyAuth library use it.

Stronger SSL Security curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1); only checks if the SSL certificate exists, 
but does not verify the hostname properly.
Change it to curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
Enforces full hostname verification, preventing MITM attacks