### PR TITLE
Fix: invalidver opt-in auto-open

### DIFF
--- a/auth.cpp
+++ b/auth.cpp
@@ -598,7 +598,7 @@ void KeyAuth::api::init()
             {
                 std::string dl = json[(XorStr("download"))];
                 api::app_data.downloadLink = dl;
-                if (autoOpenDownloadUrl) {
+                if (auto_open_download_url) {
                     if (dl.empty()) {
                         MessageBoxA(0, XorStr("Version in the loader does not match the one on the dashboard, and the download link on dashboard is blank.\n\nTo fix this, either fix the loader so it matches the version on the dashboard. Or if you intended for it to have different versions, update the download link on dashboard so it will auto-update correctly.").c_str(), NULL, MB_ICONERROR);
                     }

--- a/auth.cpp
+++ b/auth.cpp
@@ -598,17 +598,22 @@ void KeyAuth::api::init()
             {
                 std::string dl = json[(XorStr("download"))];
                 api::app_data.downloadLink = dl;
-                if (dl.empty()) {
-                    api::response.message = XorStr("Version in the loader does not match the one on the dashboard, and the download link on dashboard is blank. To fix this, either fix the loader so it matches the version on the dashboard. Or if you intended for it to have different versions, update the download link on dashboard so it will auto-update correctly.");
-                }
-                else {
-                    api::response.message = XorStr("invalidver");
-                }
                 if (autoOpenDownloadUrl) {
-                    if (!dl.empty()) {
+                    if (dl.empty()) {
+                        MessageBoxA(0, XorStr("Version in the loader does not match the one on the dashboard, and the download link on dashboard is blank.\n\nTo fix this, either fix the loader so it matches the version on the dashboard. Or if you intended for it to have different versions, update the download link on dashboard so it will auto-update correctly.").c_str(), NULL, MB_ICONERROR);
+                    }
+                    else {
                         ShellExecuteA(0, XorStr("open").c_str(), dl.c_str(), 0, 0, SW_SHOWNORMAL);
                     }
                     LI_FN(exit)(0);
+                }
+                else {
+                    if (dl.empty()) {
+                        api::response.message = XorStr("Version in the loader does not match the one on the dashboard, and the download link on dashboard is blank. To fix this, either fix the loader so it matches the version on the dashboard. Or if you intended for it to have different versions, update the download link on dashboard so it will auto-update correctly.");
+                    }
+                    else {
+                        api::response.message = XorStr("invalidver");
+                    }
                 }
             }
         }

--- a/auth.cpp
+++ b/auth.cpp
@@ -598,6 +598,12 @@ void KeyAuth::api::init()
             {
                 std::string dl = json[(XorStr("download"))];
                 api::app_data.downloadLink = dl;
+                if (dl.empty()) {
+                    api::response.message = XorStr("Version in the loader does not match the one on the dashboard, and the download link on dashboard is blank. To fix this, either fix the loader so it matches the version on the dashboard. Or if you intended for it to have different versions, update the download link on dashboard so it will auto-update correctly.");
+                }
+                else {
+                    api::response.message = XorStr("invalidver");
+                }
                 if (autoOpenDownloadUrl) {
                     if (!dl.empty()) {
                         ShellExecuteA(0, XorStr("open").c_str(), dl.c_str(), 0, 0, SW_SHOWNORMAL);

--- a/auth.cpp
+++ b/auth.cpp
@@ -597,16 +597,13 @@ void KeyAuth::api::init()
             else if (json[(XorStr("message"))] == XorStr("invalidver"))
             {
                 std::string dl = json[(XorStr("download"))];
-                api::app_data.downloadLink = json[XorStr("download")];
-                if (dl == "")
-                {
-                    MessageBoxA(0, XorStr("Version in the loader does match the one on the dashboard, and the download link on dashboard is blank.\n\nTo fix this, either fix the loader so it matches the version on the dashboard. Or if you intended for it to have different versions, update the download link on dashboard so it will auto-update correctly.").c_str(), NULL, MB_ICONERROR);
+                api::app_data.downloadLink = dl;
+                if (autoOpenDownloadUrl) {
+                    if (!dl.empty()) {
+                        ShellExecuteA(0, XorStr("open").c_str(), dl.c_str(), 0, 0, SW_SHOWNORMAL);
+                    }
+                    LI_FN(exit)(0);
                 }
-                else
-                {
-                    ShellExecuteA(0, XorStr("open").c_str(), dl.c_str(), 0, 0, SW_SHOWNORMAL);
-                }
-                LI_FN(exit)(0);
             }
         }
         else {

--- a/auth.hpp
+++ b/auth.hpp
@@ -59,7 +59,7 @@ namespace KeyAuth {
 		bool block_proxy = false;
 		bool block_custom_ca = false;
 		bool block_private_dns = false;
-		bool autoOpenDownloadUrl = true;
+		bool auto_open_download_url = true;
 		static std::string expiry_remaining(const std::string& expiry);
 		static constexpr const char* kSavePath = "test.json";
 		static constexpr int kInitFailSleepMs = 1500;

--- a/auth.hpp
+++ b/auth.hpp
@@ -59,6 +59,7 @@ namespace KeyAuth {
 		bool block_proxy = false;
 		bool block_custom_ca = false;
 		bool block_private_dns = false;
+		bool autoOpenDownloadUrl = false;
 		static std::string expiry_remaining(const std::string& expiry);
 		static constexpr const char* kSavePath = "test.json";
 		static constexpr int kInitFailSleepMs = 1500;

--- a/auth.hpp
+++ b/auth.hpp
@@ -59,7 +59,7 @@ namespace KeyAuth {
 		bool block_proxy = false;
 		bool block_custom_ca = false;
 		bool block_private_dns = false;
-		bool autoOpenDownloadUrl = false;
+		bool autoOpenDownloadUrl = true;
 		static std::string expiry_remaining(const std::string& expiry);
 		static constexpr const char* kSavePath = "test.json";
 		static constexpr int kInitFailSleepMs = 1500;


### PR DESCRIPTION
When using `invalidver` handling in my loaders, the library always opened the download URL and exited before my code could run. That prevented showing a custom error (e.g. console message + countdown) or using `app_data.downloadLink` in my own UI. This change makes the old auto-open-and-exit behavior opt-in via `auto_open_download_url`, and ensures `response.message` is set so callers can detect and display the error. Example of the flow I wanted to support:

```cpp
if (KeyAuthApp.response.message == "invalidver") {
    std::cout << "Your loader is outdated!" << std::endl;
    if (!KeyAuthApp.app_data.downloadLink.empty()) {
        std::cout << "Please visit our website to download the latest version:" << std::endl;
        std::cout << KeyAuthApp.app_data.downloadLink << std::endl;
    } else {
        std::cout << "Please download the latest version." << std::endl; // e.g. when white labeling loaders
    }
    // e.g. countdown then return 1
}
```

The default is `auto_open_download_url= true`, so existing code keeps the original behavior (open URL and exit). No changes required for current users. I consider that behavior broken for loaders that want to handle the error themselves; set `auto_open_download_url = false` before `init()` to get the new behavior.

## Summary
- **Opt-in caller handling:** A new `auto_open_download_url` flag (default `true`) controls invalidver behavior. When `true`, behavior is unchanged: open download URL if set, then exit. When `false`, the library stores the download link and returns so the caller can handle the error.
- **Descriptive error:** When the server returns `invalidver`, `response.message` is now set so callers can show a clear message:
  - If the dashboard download link is **blank**: a full diagnostic string (version mismatch + how to fix).
  - If the download link is **present**: `"invalidver"` so the caller can detect and display it.

## Behavior
| `auto_open_download_url` | Result |
|------------------------|--------|
| `true` (default)       | Same as before: open URL if non-empty, then `exit(0)`. No change for existing users. |
| `false`                | No URL open, no exit; `app_data.downloadLink` and `response.message` are set for the caller. |

## Files
- `auth.hpp`: added `bool auto_open_download_url = true;`
- `auth.cpp`: invalidver block updated to set `response.message` and to open/exit only when `auto_open_download_url` is true